### PR TITLE
[docs] Use the correct product name for Oracle Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Simply start by typing ```rwlman```.
 
 For building rwloadsim and running the test suite, these versions have been successfully tested:
 
- * Oracle Enterprise Linux 7 with gcc 4.8.5, bison 3.0.4, flex 2.5.37, database 12.2.0.1
- * Oracle Enterprise Linux 7 with gcc 4.8.5, bison 3.0.4, flex 2.5.37, database 19.9.0.0
- * Oracle Enterprise Linux 6 with gcc 4.4.7, bison 2.4.1, flex 2.5.35, database 12.2.0.1
+ * Oracle Linux 7 with gcc 4.8.5, bison 3.0.4, flex 2.5.37, database 12.2.0.1
+ * Oracle Linux 7 with gcc 4.8.5, bison 3.0.4, flex 2.5.37, database 19.9.0.0
+ * Oracle Linux 6 with gcc 4.4.7, bison 2.4.1, flex 2.5.35, database 12.2.0.1
  * Ubuntu 18.04 with gcc 7.5.0, bison 3.0.4, flex 2.6.4, database 19.4
  * Solaris 11.4 with gcc 9.2.0, bison 3.4.2, flex 2.6.4, instant client 19.8 with test database 12.2 on Linux; several of the possible differences listed in the TEST.md file are known to occur on Solaris.
 

--- a/oltp/parameters.rwl
+++ b/oltp/parameters.rwl
@@ -145,7 +145,7 @@ integer largeashok := 1;
 # and svg plotting will include this option
 # mouse jsdir '$gnuplotjs' 
 # 
-# As an example, in a standard OEL setup, as root, do this:
+# As an example, in a standard Oracle Linux setup, as root, do this:
 #
 # cd /var/www/html
 # mkdir -p usr/share/gnuplot/4.6/js
@@ -258,4 +258,3 @@ if gnuplotjs != "" then
 else
   svgmouse := "";
 end if;
-

--- a/test/TEST.md
+++ b/test/TEST.md
@@ -175,7 +175,7 @@ You should always investigate why differences are there, and if you are confiden
 results are actually good, you can overwrite the .good files to achieve a clean test.
 
 The distributed .good files were created using a database release 19.9 running
-on Oracle Enterprise Linux 7.
+on Oracle Linux 7.
 
 The following lists tests with known potential differences.
 
@@ -214,4 +214,3 @@ which may be platform specific.
 
 The correct output depends on the release of the database
 server that is being used.
-


### PR DESCRIPTION
Replaced all incorrect instances with the correct product name
for Oracle Linux.

Signed-off-by: Avi Miller <avi.miller@oracle.com>